### PR TITLE
Simplify code

### DIFF
--- a/hackmud_chat.py
+++ b/hackmud_chat.py
@@ -11,19 +11,10 @@ class Message(object):
         self.time      = msg_obj['t']
         self.text      = msg_obj['msg']
         self.from_user = msg_obj['from_user']
-        self.to_user   = None
-        self.channel   = None
-        self.is_join   = None
-        self.is_leave  = None
-
-        if 'channel' in msg_obj:
-            self.channel   = msg_obj['channel']
-        if 'is_join' in msg_obj:
-            self.is_join   = msg_obj['is_join']
-        if 'is_leave' in msg_obj:
-            self.is_leave  = msg_obj['is_leave']
-        if 'to_user' in msg_obj:
-            self.to_user = msg_obj['to_user']
+        self.to_user   = msg_obj.get('to_user')
+        self.channel   = msg_obj.get('channel')
+        self.is_join   = msg_obj.get('is_join')
+        self.is_leave  = msg_obj.get('is_leave')
 
 class User(object):
     def __init__(self, name, chan_obj, account):


### PR DESCRIPTION
Dictionaries have a method called `.get` that doesn't throw an error when a key doesn't exist, and instead returns a default value or `None` if no default is supplied. (https://docs.python.org/3/library/stdtypes.html#dict.get)

I have simplified the `__init__` method of the `Message` class so it uses `msg_obj.get` instead of if statements that check if each key exists.

I haven't changed `id`, `time`, `text` or `from_user`, because I wasn't sure if you still wanted them to throw an error if the API breaks.
